### PR TITLE
Connected fix

### DIFF
--- a/src/main/java/org/chocosolver/solver/cstrs/connectivity/PropConnected.java
+++ b/src/main/java/org/chocosolver/solver/cstrs/connectivity/PropConnected.java
@@ -112,8 +112,12 @@ public class PropConnected extends Propagator<IUndirectedGraphVar> {
 
 	@Override
 	public ESat isEntailed() {
-		if(g.getPotentialNodes().getSize()<=1){
+		if(g.getPotentialNodes().getSize()==1){
 			return ESat.TRUE;
+		}
+		//Graphs with zero nodes are not connected.
+		if(g.getMandatoryNodes().getSize() == 0){
+			return ESat.FALSE;
 		}
 		explore();
 		for(int i=g.getMandatoryNodes().getFirstElement();i>=0;i=g.getMandatoryNodes().getNextElement()){
@@ -124,9 +128,7 @@ public class PropConnected extends Propagator<IUndirectedGraphVar> {
 		if (!g.isInstantiated()) {
 			return ESat.UNDEFINED;
 		}
-		if(g.isInstantiated() && g.getMandatoryNodes().getSize() == 0){
-			return ESat.FALSE;
-		}
+
 		return ESat.TRUE;
 	}
 

--- a/src/main/java/org/chocosolver/solver/cstrs/connectivity/PropConnected.java
+++ b/src/main/java/org/chocosolver/solver/cstrs/connectivity/PropConnected.java
@@ -89,6 +89,9 @@ public class PropConnected extends Propagator<IUndirectedGraphVar> {
 
 	@Override
 	public void propagate(int evtmask) throws ContradictionException {
+		if (g.getPotentialNodes().getSize() == 0) {
+			contradiction(g, "");
+		}
 		if(g.getMandatoryNodes().getSize()>1) {
 			// explore the graph from the first mandatory node
 			explore();

--- a/src/main/java/org/chocosolver/solver/cstrs/connectivity/PropConnected.java
+++ b/src/main/java/org/chocosolver/solver/cstrs/connectivity/PropConnected.java
@@ -124,6 +124,9 @@ public class PropConnected extends Propagator<IUndirectedGraphVar> {
 		if (!g.isInstantiated()) {
 			return ESat.UNDEFINED;
 		}
+		if(g.isInstantiated() && g.getMandatoryNodes().getSize() == 0){
+			return ESat.FALSE;
+		}
 		return ESat.TRUE;
 	}
 
@@ -131,8 +134,8 @@ public class PropConnected extends Propagator<IUndirectedGraphVar> {
 		visited.clear();
 		int first = 0;
 		int last = 0;
-		if(g.getMandatoryNodes().getSize()<=1){
-			return; // empty or singleton graph
+		if(g.getMandatoryNodes().getSize()<=0){
+			return; // empty graph
 		}
 		int i = g.getMandatoryNodes().getFirstElement();
 		fifo[last++] = i;

--- a/src/test/java/org/chocosolver/checked/ConnectedTest.java
+++ b/src/test/java/org/chocosolver/checked/ConnectedTest.java
@@ -2,6 +2,7 @@ package org.chocosolver.checked;
 
 import org.chocosolver.solver.cstrs.GCF;
 import org.chocosolver.solver.variables.IUndirectedGraphVar;
+import org.chocosolver.util.ESat;
 import org.chocosolver.util.objects.graphs.UndirectedGraph;
 import org.testng.annotations.Test;
 import org.chocosolver.solver.Solver;
@@ -11,6 +12,8 @@ import org.chocosolver.solver.variables.GraphVarFactory;
 import org.chocosolver.solver.variables.IDirectedGraphVar;
 import org.chocosolver.util.objects.graphs.DirectedGraph;
 import org.chocosolver.util.objects.setDataStructures.SetType;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  * Created by ezulkosk on 5/22/15.
@@ -36,13 +39,16 @@ public class ConnectedTest {
         IUndirectedGraphVar graph = GraphVarFactory.undirected_graph_var("G", GLB, GUB, solver);
         GCF.connected(graph).reif();
 
-        System.out.println("TEST (should return UNDEFINED): " + GCF.connected(graph).getPropagator(0).isEntailed());
+        assertEquals(GCF.connected(graph).getPropagator(0).isEntailed(), ESat.UNDEFINED);
 
         solver.post(GraphConstraintFactory.connected(graph));
         solver.set(GraphStrategyFactory.lexico(graph));
 
         if (solver.findSolution()) {
-            System.out.println(solver.isSatisfied());
+            System.out.println("Solution: " + solver.nextSolution());
+        }
+        else{
+            System.out.println("No solutions.");
         }
 
     }
@@ -54,16 +60,20 @@ public class ConnectedTest {
         UndirectedGraph GLB = new UndirectedGraph(solver,2, SetType.BITSET,false);
         UndirectedGraph GUB = new UndirectedGraph(solver,2,SetType.BITSET,false);
 
+        //empty graphs are traditionally *not* connected.
         IUndirectedGraphVar graph = GraphVarFactory.undirected_graph_var("G", GLB, GUB, solver);
         GCF.connected(graph).reif();
 
-        System.out.println("TEST (should return UNDEFINED): " + GCF.connected(graph).getPropagator(0).isEntailed());
+        assertEquals(GCF.connected(graph).getPropagator(0).isEntailed(), ESat.FALSE);
 
-        solver.post(GraphConstraintFactory.connected(graph));
+        solver.post(GraphConstraintFactory.connected(graph).getOpposite());
         solver.set(GraphStrategyFactory.lexico(graph));
 
         if (solver.findSolution()) {
-            System.out.println(solver.isSatisfied());
+            System.out.println("Solution: " + solver.nextSolution());
+        }
+        else{
+            System.out.println("No solutions.");
         }
 
     }

--- a/src/test/java/org/chocosolver/checked/ConnectedTest.java
+++ b/src/test/java/org/chocosolver/checked/ConnectedTest.java
@@ -1,0 +1,70 @@
+package org.chocosolver.checked;
+
+import org.chocosolver.solver.cstrs.GCF;
+import org.chocosolver.solver.variables.IUndirectedGraphVar;
+import org.chocosolver.util.objects.graphs.UndirectedGraph;
+import org.testng.annotations.Test;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.cstrs.GraphConstraintFactory;
+import org.chocosolver.solver.search.GraphStrategyFactory;
+import org.chocosolver.solver.variables.GraphVarFactory;
+import org.chocosolver.solver.variables.IDirectedGraphVar;
+import org.chocosolver.util.objects.graphs.DirectedGraph;
+import org.chocosolver.util.objects.setDataStructures.SetType;
+
+/**
+ * Created by ezulkosk on 5/22/15.
+ */
+
+
+
+public class ConnectedTest {
+
+    @Test(groups = "10s")
+    public void testChocoConnected() {
+        Solver solver = new Solver();
+        // build model
+        UndirectedGraph GLB = new UndirectedGraph(solver,2, SetType.BITSET,false);
+        UndirectedGraph GUB = new UndirectedGraph(solver,2,SetType.BITSET,false);
+
+        GLB.addNode(0);
+
+        GUB.addNode(0);
+        GUB.addNode(1);
+        GUB.addEdge(0,1);
+
+        IUndirectedGraphVar graph = GraphVarFactory.undirected_graph_var("G", GLB, GUB, solver);
+        GCF.connected(graph).reif();
+
+        System.out.println("TEST (should return UNDEFINED): " + GCF.connected(graph).getPropagator(0).isEntailed());
+
+        solver.post(GraphConstraintFactory.connected(graph));
+        solver.set(GraphStrategyFactory.lexico(graph));
+
+        if (solver.findSolution()) {
+            System.out.println(solver.isSatisfied());
+        }
+
+    }
+
+    @Test(groups = "10s")
+    public void testChocoConnected2() {
+        Solver solver = new Solver();
+        // build model
+        UndirectedGraph GLB = new UndirectedGraph(solver,2, SetType.BITSET,false);
+        UndirectedGraph GUB = new UndirectedGraph(solver,2,SetType.BITSET,false);
+
+        IUndirectedGraphVar graph = GraphVarFactory.undirected_graph_var("G", GLB, GUB, solver);
+        GCF.connected(graph).reif();
+
+        System.out.println("TEST (should return UNDEFINED): " + GCF.connected(graph).getPropagator(0).isEntailed());
+
+        solver.post(GraphConstraintFactory.connected(graph));
+        solver.set(GraphStrategyFactory.lexico(graph));
+
+        if (solver.findSolution()) {
+            System.out.println(solver.isSatisfied());
+        }
+
+    }
+}

--- a/src/test/java/org/chocosolver/checked/ConnectedTest.java
+++ b/src/test/java/org/chocosolver/checked/ConnectedTest.java
@@ -1,6 +1,7 @@
 package org.chocosolver.checked;
 
 import org.chocosolver.solver.cstrs.GCF;
+import org.chocosolver.solver.variables.GVF;
 import org.chocosolver.solver.variables.IUndirectedGraphVar;
 import org.chocosolver.util.ESat;
 import org.chocosolver.util.objects.graphs.UndirectedGraph;
@@ -64,7 +65,7 @@ public class ConnectedTest {
         IUndirectedGraphVar graph = GraphVarFactory.undirected_graph_var("G", GLB, GUB, solver);
         GCF.connected(graph).reif();
 
-        assertEquals(GCF.connected(graph).getPropagator(0).isEntailed(), ESat.FALSE);
+            assertEquals(GCF.connected(graph).getPropagator(0).isEntailed(), ESat.FALSE);
 
         solver.post(GraphConstraintFactory.connected(graph).getOpposite());
         solver.set(GraphStrategyFactory.lexico(graph));
@@ -76,5 +77,26 @@ public class ConnectedTest {
             System.out.println("No solutions.");
         }
 
+    }
+
+    @Test(groups = "10s")
+    public void testChocoConnected3() {
+        Solver s = new Solver();
+        UndirectedGraph LB = new UndirectedGraph(s, 2, SetType.BITSET, false);
+        UndirectedGraph UB = new UndirectedGraph(s, 2, SetType.BITSET, false);
+        UB.addNode(0);
+        UB.addNode(1);
+        UB.addEdge(0, 1);
+        IUndirectedGraphVar g = GVF.undirected_graph_var("g", LB, UB, s);
+
+        s.post(GCF.connected(g));
+        s.set(GraphStrategyFactory.lexico(g));
+
+        if (s.findSolution()) {
+            do {
+                System.out.println(s.isSatisfied());
+                System.out.println(g);
+            } while (s.nextSolution());
+        }
     }
 }


### PR DESCRIPTION
As illustrated by testChocoConnected, a non-instantiated graph variable with one mandatory node should return UNDEFINED from isEntailed(), as opposed to TRUE.

Further, graphs with zero nodes should be defined to not be connected, as this is the typical definition.