### PR TITLE
Symmetry breaking predicates for directed and undirected graphs

### DIFF
--- a/src/main/java/org/chocosolver/solver/cstrs/GraphConstraintFactory.java
+++ b/src/main/java/org/chocosolver/solver/cstrs/GraphConstraintFactory.java
@@ -26,8 +26,10 @@
  */
 package org.chocosolver.solver.cstrs;
 
+import org.chocosolver.solver.Solver;
 import org.chocosolver.solver.constraints.Constraint;
 import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.constraints.LCF;
 import org.chocosolver.solver.constraints.Propagator;
 import org.chocosolver.solver.cstrs.basic.*;
 import org.chocosolver.solver.cstrs.channeling.edges.*;
@@ -45,6 +47,10 @@ import org.chocosolver.solver.cstrs.cost.tsp.lagrangianRelaxation.PropLagr_OneTr
 import org.chocosolver.solver.cstrs.cycles.*;
 import org.chocosolver.solver.cstrs.degree.*;
 import org.chocosolver.solver.cstrs.inclusion.PropInclusion;
+import org.chocosolver.solver.cstrs.symmbreaking.PropIncrementalAdjacencyMatrix;
+import org.chocosolver.solver.cstrs.symmbreaking.PropIncrementalAdjacencyUndirectedMatrix;
+import org.chocosolver.solver.cstrs.symmbreaking.PropSymmetryBreaking;
+import org.chocosolver.solver.cstrs.symmbreaking.PropSymmetryBreakingEx;
 import org.chocosolver.solver.cstrs.tree.PropArborescence;
 import org.chocosolver.solver.cstrs.tree.PropArborescences;
 import org.chocosolver.solver.cstrs.tree.PropReachability;
@@ -1028,4 +1034,261 @@ public class GraphConstraintFactory {
 		}
 		return new Constraint("dcmst",props);
 	}
+
+	//***********************************************************************************
+	// SYMMETRY BREAKING CONSTRAINTS
+	//***********************************************************************************
+
+	/**
+	 * Post a symmetry breaking constraint. This constraint is a symmetry breaking for
+	 * class of directed graphs which contain a directed tree with root in node 0.
+	 * (All nodes must be reachable from node 0)
+	 * Note, that this method post this constraint directly, so it cannot be reified.
+	 * If you need to get a single {@link Constraint} use {@link #symmetryBreaking(IDirectedGraphVar, Solver)}.
+	 *
+	 * This symmetry breaking method based on paper:
+	 *     Ulyantsev V., Zakirzyanov I., Shalyto A.
+	 * 	   BFS-Based Symmetry Breaking Predicates for DFA Identification
+	 *     //Language and Automata Theory and Applications. – Springer International Publishing, 2015. – С. 611-622.
+	 *
+	 *
+	 * @param graph graph to be constrainted
+	 * @param solver solver to post constraint
+	 */
+	public static void postSymmetryBreaking(IDirectedGraphVar graph, Solver solver) {
+		// ---------------------- variables ------------------------
+		int n = graph.getNbMaxNodes();
+		// t[i, j]
+		BoolVar[] t = VF.boolArray("T[]", n * n, solver);
+		// p[i]
+		IntVar[] p = new IntVar[n];
+		p[0] = VF.fixed("P[0]", 0, solver);
+		for (int i = 1; i < n; i++) {
+			p[i] = VF.integer("P[" + i + "]", 0, i - 1, solver);
+		}
+		// ---------------------- constraints -----------------------
+		// t[i, j] <-> G
+		solver.post(new Constraint("AdjacencyMatrix", new PropIncrementalAdjacencyMatrix(graph, t)));
+
+		// (p[j] == i) ⇔ t[i, j] and AND(!t[k, j], 0 ≤ k < j)
+		for (int i = 0; i < n - 1; i++) {
+			IntVar I = VF.fixed(i, solver);
+			for (int j = 1; j < n; j++) {
+				BoolVar[] clause = new BoolVar[i + 1];
+				clause[i] = t[i + j * n];
+				for (int k = 0; k < i; k++) {
+					clause[k] = t[k + j * n].not();
+				}
+				Constraint c = LCF.and(clause);
+				Constraint pij = ICF.arithm(p[j], "=", I);
+				LCF.ifThen(pij, c);
+				LCF.ifThen(c, pij);
+			}
+		}
+
+		// p[i] ≤ p[i + 1]
+		for (int i = 1; i < n - 1; i++) {
+			solver.post(ICF.arithm(p[i], "<=", p[i + 1]));
+		}
+	}
+
+	/**
+	 * Post a symmetry breaking constraint. This constraint is a symmetry breaking for
+	 * class of undirected connected graphs.
+	 * Note, that this method post this constraint directly, so it cannot be reified.
+	 * If you need to get a single {@link Constraint} use {@link #symmetryBreaking(IUndirectedGraphVar, Solver)}.
+	 *
+	 * This symmetry breaking method based on paper:
+	 *     Ulyantsev V., Zakirzyanov I., Shalyto A.
+	 * 	   BFS-Based Symmetry Breaking Predicates for DFA Identification
+	 *     //Language and Automata Theory and Applications. – Springer International Publishing, 2015. – С. 611-622.
+	 *
+	 * @param graph graph to be constrainted
+	 * @param solver solver to post constraint
+	 */
+	public static void postSymmetryBreaking(IUndirectedGraphVar graph, Solver solver) {
+		// ---------------------- variables ------------------------
+		int n = graph.getNbMaxNodes();
+
+		// t[i, j]
+		BoolVar[] t = VF.boolArray("T[]", n * n, solver);
+
+		// p[i]
+		IntVar[] p = new IntVar[n];
+		p[0] = VF.fixed("P[0]", 0, solver);
+		for (int i = 1; i < n; i++) {
+			p[i] = VF.integer("P[" + i + "]", 0, i - 1, solver);
+		}
+		// ---------------------- constraints -----------------------
+		// t[i, j] <-> G
+		solver.post(new Constraint("AdjacencyMatrix", new PropIncrementalAdjacencyUndirectedMatrix(graph, t)));
+
+		// (p[j] == i) ⇔ t[i, j] and AND(!t[k, j], 0 ≤ k < j)
+		for (int i = 0; i < n - 1; i++) {
+			IntVar I = VF.fixed(i, solver);
+			for (int j = 1; j < n; j++) {
+				BoolVar[] clause = new BoolVar[i + 1];
+				clause[i] = t[i + j * n];
+				for (int k = 0; k < i; k++) {
+					clause[k] = t[k + j * n].not();
+				}
+				Constraint c = LCF.and(clause);
+				Constraint pij = ICF.arithm(p[j], "=", I);
+				LCF.ifThen(pij, c);
+				LCF.ifThen(c, pij);
+			}
+		}
+
+		// p[i] ≤ p[i + 1]
+		for (int i = 1; i < n - 1; i++) {
+			solver.post(ICF.arithm(p[i], "<=", p[i + 1]));
+		}
+	}
+
+	/**
+	 * Does the same as {@link #postSymmetryBreaking(IDirectedGraphVar, Solver)}, but
+	 * post nothing and return single {@link Constraint}.
+	 * It can be reified, but beware: it should be posted manually and it can be slower.
+	 *
+	 * @param graph graph to be constrainted
+	 * @param solver solver, connected to graph
+	 */
+	public static Constraint symmetryBreaking(IUndirectedGraphVar graph, Solver solver) {
+		// ---------------------- variables ------------------------
+		int n = graph.getNbMaxNodes();
+
+		// t[i, j]
+		BoolVar[] t = VF.boolArray("T[]", n * n, solver);
+
+		// p[i]
+		IntVar[] p = new IntVar[n];
+		p[0] = VF.fixed("P[0]", 0, solver);
+		for (int i = 1; i < n; i++) {
+			p[i] = VF.integer("P[" + i + "]", 0, i - 1, solver);
+		}
+		// ---------------------- constraints -----------------------
+		// t[i, j] <-> G
+		Constraint first = new Constraint("AdjacencyMatrix", new PropIncrementalAdjacencyUndirectedMatrix(graph, t));
+
+		// (p[j] == i) ⇔ t[i, j] and AND(!t[k, j], 0 ≤ k < j)
+		Constraint[] secondA = new Constraint[(n - 1) * (n - 1)];
+		Constraint[] secondB = new Constraint[(n - 1) * (n - 1)];
+		for (int i = 0; i < n - 1; i++) {
+			IntVar I = VF.fixed(i, solver);
+			for (int j = 1; j < n; j++) {
+				BoolVar[] clause = new BoolVar[i + 1];
+				clause[i] = t[i + j * n];
+				for (int k = 0; k < i; k++) {
+					clause[k] = t[k + j * n].not();
+				}
+				Constraint c = LCF.and(clause);
+				Constraint pij = ICF.arithm(p[j], "=", I);
+				secondA[i + (j - 1) * (n - 1)] = LCF.ifThen_reifiable(pij, c);
+				secondB[i + (j - 1) * (n - 1)] = LCF.ifThen_reifiable(c, pij);
+			}
+		}
+
+		// p[i] ≤ p[i + 1]
+		Constraint[] third = new Constraint[n - 1];
+		for (int i = 1; i < n - 1; i++) {
+			third[i - 1] = ICF.arithm(p[i], "<=", p[i + 1]);
+		}
+		Constraint[] all = ArrayUtils.append(new Constraint[] {first}, secondA, secondB, third);
+		return LCF.and(all);
+	}
+
+	/**
+	 * Does the same as {@link #postSymmetryBreaking(IUndirectedGraphVar, Solver)}, but
+	 * post nothing and return single {@link Constraint}.
+	 * It can be reified, but beware: it should be posted manually and it can be slower.
+	 *
+	 * @param graph graph to be constrainted
+	 * @param solver solver, connected to graph
+	 */
+	public static Constraint symmetryBreaking(IDirectedGraphVar graph, Solver solver) {
+		// ---------------------- variables ------------------------
+		int n = graph.getNbMaxNodes();
+
+		// t[i, j]
+		BoolVar[] t = VF.boolArray("T[]", n * n, solver);
+
+		// p[i]
+		IntVar[] p = new IntVar[n];
+		p[0] = VF.fixed("P[0]", 0, solver);
+		for (int i = 1; i < n; i++) {
+			p[i] = VF.integer("P[" + i + "]", 0, i - 1, solver);
+		}
+		// ---------------------- constraints -----------------------
+		// t[i, j] <-> G
+		Constraint first = new Constraint("AdjacencyMatrix", new PropIncrementalAdjacencyMatrix(graph, t));
+
+		// (p[j] == i) ⇔ t[i, j] and AND(!t[k, j], 0 ≤ k < j)
+		Constraint[] secondA = new Constraint[(n - 1) * (n - 1)];
+		Constraint[] secondB = new Constraint[(n - 1) * (n - 1)];
+		for (int i = 0; i < n - 1; i++) {
+			IntVar I = VF.fixed(i, solver);
+			for (int j = 1; j < n; j++) {
+				BoolVar[] clause = new BoolVar[i + 1];
+				clause[i] = t[i + j * n];
+				for (int k = 0; k < i; k++) {
+					clause[k] = t[k + j * n].not();
+				}
+				Constraint c = LCF.and(clause);
+				Constraint pij = ICF.arithm(p[j], "=", I);
+				secondA[i + (j - 1) * (n - 1)] = LCF.ifThen_reifiable(pij, c);
+				secondB[i + (j - 1) * (n - 1)] = LCF.ifThen_reifiable(c, pij);
+			}
+		}
+
+		// p[i] ≤ p[i + 1]
+		Constraint[] third = new Constraint[n - 1];
+		for (int i = 1; i < n - 1; i++) {
+			third[i - 1] = ICF.arithm(p[i], "<=", p[i + 1]);
+		}
+		Constraint[] all = ArrayUtils.append(new Constraint[] {first}, secondA, secondB, third);
+		return LCF.and(all);
+	}
+
+	/**
+	 * Creates a symmetry breaking constraint. This constraint is a symmetry breaking for
+	 * class of undirected connected graphs.
+	 *
+	 * This symmetry breaking method based on paper:
+	 *     Codish M. et al.
+	 *     Breaking Symmetries in Graph Representation
+	 *     //IJCAI. – 2013. – С. 3-9.
+	 *
+	 * @param graph graph to be constrainted
+	 * @param solver solver to associate variables with
+	 */
+	public static Constraint symmetryBreaking2(IUndirectedGraphVar graph, Solver solver) {
+		int n = graph.getNbMaxNodes();
+		BoolVar[] t = VF.boolArray("T[]", n * n, solver);
+		return new Constraint("symmBreak",
+				new PropIncrementalAdjacencyUndirectedMatrix(graph, t),
+				new PropSymmetryBreaking(t)
+		);
+	}
+
+	/**
+	 * Creates a symmetry breaking constraint. This constraint is a symmetry breaking for
+	 * class of undirected connected graphs.
+	 *
+	 * This symmetry breaking method based on paper:
+	 *     Codish M. et al.
+	 *     Breaking Symmetries in Graph Representation
+	 *     //IJCAI. – 2013. – С. 3-9.
+	 *
+	 * @param graph graph to be constrainted
+	 * @param solver solver to associate variables with
+	 */
+	public static Constraint symmetryBreaking3(IUndirectedGraphVar graph, Solver solver) {
+		int n = graph.getNbMaxNodes();
+		BoolVar[] t = VF.boolArray("T[]", n * n, solver);
+		return new Constraint("symmBreakEx",
+				new PropIncrementalAdjacencyUndirectedMatrix(graph, t),
+				new PropSymmetryBreakingEx(t)
+		);
+	}
+
 }

--- a/src/main/java/org/chocosolver/solver/cstrs/symmbreaking/PropIncrementalAdjacencyMatrix.java
+++ b/src/main/java/org/chocosolver/solver/cstrs/symmbreaking/PropIncrementalAdjacencyMatrix.java
@@ -1,0 +1,130 @@
+package org.chocosolver.solver.cstrs.symmbreaking;
+
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.*;
+import org.chocosolver.solver.variables.delta.IGraphDeltaMonitor;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+import org.chocosolver.util.objects.setDataStructures.iterableSet.ItSet;
+import org.chocosolver.util.procedure.PairProcedure;
+import org.chocosolver.util.tools.ArrayUtils;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Моклев Вячеслав
+ */
+public class PropIncrementalAdjacencyMatrix extends Propagator<Variable> {
+    IDirectedGraphVar graph;
+    IGraphDeltaMonitor gdm;
+    PairProcedure enforce;
+    PairProcedure remove;
+    int n;
+    BoolVar[] t;
+
+    public PropIncrementalAdjacencyMatrix(IDirectedGraphVar graphVar, BoolVar[] t) {
+        super(ArrayUtils.append(new Variable[]{graphVar}, t), PropagatorPriority.LINEAR, true);
+        graph = graphVar;
+        gdm = graph.monitorDelta(this);
+        enforce = (PairProcedure) (from, to) -> {
+            t[from + to * n].instantiateTo(1, this);
+        };
+        remove = (PairProcedure) (from, to) -> {
+            t[from + to * n].instantiateTo(0, this);
+        };
+        n = graphVar.getNbMaxNodes();
+        this.t = t;
+    }
+
+    @Override
+    public void propagate(int evtmask) throws ContradictionException {
+        // first, nonincremental propagation
+        propagateGraphChanged();
+        propagateTChanged();
+        // initializing incremental data-structures
+        gdm.unfreeze();
+    }
+
+    private void propagateGraphChanged() throws ContradictionException {
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (t[i + j * n].isInstantiatedTo(1)) {
+                    graph.enforceArc(i, j, this);
+                }
+                if (t[i + j * n].isInstantiatedTo(0)) {
+                    graph.removeArc(i, j, this);
+                }
+            }
+        }
+    }
+
+    private void propagateTChanged() throws ContradictionException {
+        for (int u = 0; u < n; u++) {
+            for (int v: new ItSet(graph.getMandSuccOf(u))) {
+                t[u + v * n].instantiateTo(1, this);
+            }
+        }
+        for (int u = 0; u < n; u++) {
+            Set<Integer> set = new HashSet<>();
+            for (int v: new ItSet(graph.getPotSuccOf(u))) {
+                set.add(v);
+            }
+            for (int v = 0; v < n; v++) {
+                if (!set.contains(v)) {
+                    t[u + v * n].instantiateTo(0, this);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void propagate(int idxVarInProp, int mask) throws ContradictionException {
+        // incremental propagation
+        if (idxVarInProp == 0) {
+            gdm.freeze();
+            gdm.forEachArc(enforce, GraphEventType.ADD_ARC);
+            gdm.forEachArc(remove, GraphEventType.REMOVE_ARC);
+            gdm.unfreeze();
+        } else {
+            propagateTChanged();
+        }
+    }
+
+    @Override
+    public int getPropagationConditions(int vIdx) {
+        if (vIdx == 0) {
+            return GraphEventType.ADD_ARC.getMask() | GraphEventType.REMOVE_ARC.getMask();
+        } else {
+            return IntEventType.boundAndInst();
+        }
+    }
+
+    @Override
+    public ESat isEntailed() {
+        for (int i = 0; i < n; i++) {
+            ISet children = graph.getMandSuccOf(i);
+            for (int j = 0; j < n; j++) {
+                if (t[i + j * n].isInstantiatedTo(0)  && children.contain(j)) {
+                    return ESat.FALSE;
+                }
+            }
+        }
+        for (int i = 0; i < n; i++) {
+            ISet children = graph.getPotSuccOf(i);
+            for (int j = 0; j < n; j++) {
+                if (t[i + j * n].isInstantiatedTo(1) && !children.contain(j)) {
+                    return ESat.FALSE;
+                }
+            }
+        }
+        if (graph.isInstantiated()) {
+            return ESat.TRUE;
+        }
+        return ESat.UNDEFINED;
+    }
+}
+

--- a/src/main/java/org/chocosolver/solver/cstrs/symmbreaking/PropIncrementalAdjacencyUndirectedMatrix.java
+++ b/src/main/java/org/chocosolver/solver/cstrs/symmbreaking/PropIncrementalAdjacencyUndirectedMatrix.java
@@ -1,0 +1,137 @@
+package org.chocosolver.solver.cstrs.symmbreaking;
+
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.GraphEventType;
+import org.chocosolver.solver.variables.IUndirectedGraphVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.delta.IGraphDeltaMonitor;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+import org.chocosolver.util.objects.setDataStructures.iterableSet.ItSet;
+import org.chocosolver.util.procedure.PairProcedure;
+import org.chocosolver.util.tools.ArrayUtils;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Моклев Вячеслав
+ */
+public class PropIncrementalAdjacencyUndirectedMatrix extends Propagator<Variable> {
+    IUndirectedGraphVar graph;
+    IGraphDeltaMonitor gdm;
+    PairProcedure enforce;
+    PairProcedure remove;
+    int n;
+    BoolVar[] t;
+
+    public PropIncrementalAdjacencyUndirectedMatrix(IUndirectedGraphVar graphVar, BoolVar[] t) {
+        super(ArrayUtils.append(new Variable[]{graphVar}, t), PropagatorPriority.LINEAR, true);
+        graph = graphVar;
+        gdm = graph.monitorDelta(this);
+        enforce = (PairProcedure) (from, to) -> {
+            t[from + to * n].instantiateTo(1, this);
+            t[to + from * n].instantiateTo(1, this);
+        };
+        remove = (PairProcedure) (from, to) -> {
+            t[from + to * n].instantiateTo(0, this);
+            t[to + from * n].instantiateTo(0, this);
+        };
+        n = graphVar.getNbMaxNodes();
+        this.t = t;
+    }
+
+    @Override
+    public void propagate(int evtmask) throws ContradictionException {
+        // first, nonincremental propagation
+        for (int i = 0; i < n; i++) {
+            t[i + i * n].instantiateTo(0, this);
+        }
+        propagateGraphChanged();
+        propagateTChanged();
+        // initializing incremental data-structures
+        gdm.unfreeze();
+    }
+
+    private void propagateGraphChanged() throws ContradictionException {
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (t[i + j * n].isInstantiatedTo(1)) {
+                    graph.enforceArc(i, j, this);
+                }
+                if (t[i + j * n].isInstantiatedTo(0)) {
+                    graph.removeArc(i, j, this);
+                }
+            }
+        }
+    }
+
+    private void propagateTChanged() throws ContradictionException {
+        for (int u = 0; u < n; u++) {
+            for (int v: new ItSet(graph.getMandNeighOf(u))) {
+                t[u + v * n].instantiateTo(1, this);
+            }
+        }
+        for (int u = 0; u < n; u++) {
+            Set<Integer> set = new HashSet<>();
+            for (int v: new ItSet(graph.getPotNeighOf(u))) {
+                set.add(v);
+            }
+            for (int v = 0; v < n; v++) {
+                if (!set.contains(v)) {
+                    t[u + v * n].instantiateTo(0, this);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void propagate(int idxVarInProp, int mask) throws ContradictionException {
+        // incremental propagation
+        if (idxVarInProp == 0) {
+            gdm.freeze();
+            gdm.forEachArc(enforce, GraphEventType.ADD_ARC);
+            gdm.forEachArc(remove, GraphEventType.REMOVE_ARC);
+            gdm.unfreeze();
+        } else {
+            propagateTChanged();
+        }
+    }
+
+    @Override
+    public int getPropagationConditions(int vIdx) {
+        if (vIdx == 0) {
+            return GraphEventType.ADD_ARC.getMask() | GraphEventType.REMOVE_ARC.getMask();
+        } else {
+            return IntEventType.boundAndInst();
+        }
+    }
+
+    @Override
+    public ESat isEntailed() {
+        for (int i = 0; i < n; i++) {
+            ISet children = graph.getMandNeighOf(i);
+            for (int j = 0; j < n; j++) {
+                if ((t[i + j * n].isInstantiatedTo(0) || t[j + i * n].isInstantiatedTo(0)) && children.contain(j)) {
+                    return ESat.FALSE;
+                }
+            }
+        }
+        for (int i = 0; i < n; i++) {
+            ISet children = graph.getPotNeighOf(i);
+            for (int j = 0; j < n; j++) {
+                if ((t[i + j * n].isInstantiatedTo(1) || t[j + i * n].isInstantiatedTo(1)) && !children.contain(j)) {
+                    return ESat.FALSE;
+                }
+            }
+        }
+        if (graph.isInstantiated()) {
+            return ESat.TRUE;
+        }
+        return ESat.UNDEFINED;
+    }
+}

--- a/src/main/java/org/chocosolver/solver/cstrs/symmbreaking/PropSymmetryBreaking.java
+++ b/src/main/java/org/chocosolver/solver/cstrs/symmbreaking/PropSymmetryBreaking.java
@@ -1,0 +1,91 @@
+package org.chocosolver.solver.cstrs.symmbreaking;
+
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.util.ESat;
+
+/**
+ * @author Моклев Вячеслав
+ */
+public class PropSymmetryBreaking extends Propagator<BoolVar> {
+    int n;
+    BoolVar[] t;
+
+    public PropSymmetryBreaking(BoolVar[] t) {
+        super(t, PropagatorPriority.QUADRATIC, false);
+        n = (int) Math.round(Math.sqrt(t.length));
+        this.t = t;
+    }
+
+    private enum Cmp {
+        LESS, EQUALS, GREATER, UNDEFINED
+    }
+
+    private Cmp compare(BoolVar a, BoolVar b) throws ContradictionException {
+        if (a.isInstantiatedTo(0) && b.isInstantiatedTo(1)) {
+            return Cmp.LESS;
+        }
+        if ((a.isInstantiatedTo(0) && b.isInstantiatedTo(0)) || (a.isInstantiatedTo(1) && b.isInstantiatedTo(1))) {
+            return Cmp.EQUALS;
+        }
+        if (a.isInstantiatedTo(1) && b.isInstantiatedTo(0)) {
+            return Cmp.GREATER;
+        }
+        return Cmp.UNDEFINED;
+    }
+
+    private boolean lessOrEquals(int j1, int j2) throws ContradictionException {
+        for (int i = 0; i < n; i++) {
+            if (t[i + j1 * n].isInstantiatedTo(1)) {
+                t[i + j2 * n].instantiateTo(1, this);
+            }
+            Cmp cmp = compare(t[i + j1 * n], t[i + j2 * n]);
+            // lexicographically less or undefined
+            if (cmp == Cmp.LESS || cmp == Cmp.UNDEFINED) {
+                return true;
+            }
+            // lexicographically greater
+            if (cmp == Cmp.GREATER) {
+                return false;
+            }
+        }
+        // entirely equals
+        return true;
+    }
+
+    private boolean sorted() throws ContradictionException {
+        for (int j = 0; j < n - 1; j++) {
+            if (!lessOrEquals(j, j + 1)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void propagate(int evtmask) throws ContradictionException {
+        if (!sorted()) {
+            throw new ContradictionException();
+        }
+    }
+
+    @Override
+    public ESat isEntailed() {
+        try {
+            if (!sorted()) {
+                return ESat.FALSE;
+            }
+        } catch (ContradictionException e) {
+            return ESat.FALSE;
+        }
+        for (BoolVar aT : t) {
+            if (!aT.isInstantiated()) {
+                return ESat.UNDEFINED;
+            }
+        }
+        return ESat.TRUE;
+    }
+}
+

--- a/src/main/java/org/chocosolver/solver/cstrs/symmbreaking/PropSymmetryBreakingEx.java
+++ b/src/main/java/org/chocosolver/solver/cstrs/symmbreaking/PropSymmetryBreakingEx.java
@@ -1,0 +1,93 @@
+package org.chocosolver.solver.cstrs.symmbreaking;
+
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.util.ESat;
+
+/**
+ * @author Моклев Вячеслав
+ */
+public class PropSymmetryBreakingEx extends Propagator<BoolVar> {
+    int n;
+    BoolVar[] t;
+
+    public PropSymmetryBreakingEx(BoolVar[] t) {
+        super(t, PropagatorPriority.CUBIC, false);
+        n = (int) Math.round(Math.sqrt(t.length));
+        this.t = t;
+    }
+
+    private enum Cmp {
+        LESS, EQUALS, GREATER, UNDEFINED
+    }
+
+    private Cmp compare(BoolVar a, BoolVar b) throws ContradictionException {
+        if (a.isInstantiatedTo(0) && b.isInstantiatedTo(1)) {
+            return Cmp.LESS;
+        }
+        if ((a.isInstantiatedTo(0) && b.isInstantiatedTo(0)) || (a.isInstantiatedTo(1) && b.isInstantiatedTo(1))) {
+            return Cmp.EQUALS;
+        }
+        if (a.isInstantiatedTo(1) && b.isInstantiatedTo(0)) {
+            return Cmp.GREATER;
+        }
+        return Cmp.UNDEFINED;
+    }
+
+    private boolean lessOrEqualsEx(int j1, int j2) throws ContradictionException {
+        for (int i = 0; i < n; i++) {
+            if (i == j1 || i == j2) continue;
+            if (t[i + j1 * n].isInstantiatedTo(1)) {
+                t[i + j2 * n].instantiateTo(1, this);
+            }
+            Cmp cmp = compare(t[i + j1 * n], t[i + j2 * n]);
+            // lexicographically less or undefined
+            if (cmp == Cmp.LESS || cmp == Cmp.UNDEFINED) {
+                return true;
+            }
+            // lexicographically greater
+            if (cmp == Cmp.GREATER) {
+                return false;
+            }
+        }
+        // entirely equals
+        return true;
+    }
+
+    private boolean sortedEx() throws ContradictionException {
+        for (int j = 1; j < n; j++) {
+            for (int i = 0; i < j; i++) {
+                if (j - i != 2 && !lessOrEqualsEx(i, j)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void propagate(int evtmask) throws ContradictionException {
+        if (!sortedEx()) {
+            throw new ContradictionException();
+        }
+    }
+
+    @Override
+    public ESat isEntailed() {
+        try {
+            if (!sortedEx()) {
+                return ESat.FALSE;
+            }
+        } catch (ContradictionException e) {
+            return ESat.FALSE;
+        }
+        for (BoolVar aT : t) {
+            if (!aT.isInstantiated()) {
+                return ESat.UNDEFINED;
+            }
+        }
+        return ESat.TRUE;
+    }
+}

--- a/src/main/java/org/chocosolver/util/objects/setDataStructures/iterableSet/ItSet.java
+++ b/src/main/java/org/chocosolver/util/objects/setDataStructures/iterableSet/ItSet.java
@@ -1,0 +1,82 @@
+package org.chocosolver.util.objects.setDataStructures.iterableSet;
+
+import org.chocosolver.util.objects.setDataStructures.ISet;
+import org.chocosolver.util.objects.setDataStructures.SetType;
+
+import java.util.Iterator;
+
+/**
+ * @author Моклев Вячеслав
+ */
+public class ItSet implements Iterator<Integer>, Iterable<Integer> {
+    private ISet set;
+    private int element;
+
+    @Override
+    public Iterator<Integer> iterator() {
+        return this;
+    }
+
+    public ItSet(ISet set) {
+        this.set = set;
+        element = set.getFirstElement();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return element >= 0;
+    }
+
+    @Override
+    public Integer next() {
+        int result = element;
+        element = set.getNextElement();
+        return result;
+    }
+
+    // methods of ISet
+
+    public boolean add(int element) {
+        return set.add(element);
+    }
+
+    public void clear() {
+        set.clear();
+    }
+
+    public boolean contain(int element) {
+        return set.contain(element);
+    }
+
+    public int getMaxSize() {
+        return set.getMaxSize();
+    }
+
+    public SetType getSetType() {
+        return set.getSetType();
+    }
+
+    public int[] toArray() {
+        return set.toArray();
+    }
+
+    public int getFirstElement() {
+        return set.getFirstElement();
+    }
+
+    public int getNextElement() {
+        return set.getNextElement();
+    }
+
+    public boolean remove(int element) {
+        return set.remove(element);
+    }
+
+    public boolean isEmpty() {
+        return set.isEmpty();
+    }
+
+    public int getSize() {
+        return set.getSize();
+    }
+}

--- a/src/test/java/org/chocosolver/SymmetryBreakingDirectedTest.java
+++ b/src/test/java/org/chocosolver/SymmetryBreakingDirectedTest.java
@@ -1,0 +1,156 @@
+package org.chocosolver;
+
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.cstrs.GCF;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.search.GraphStrategyFactory;
+import org.chocosolver.solver.variables.GraphVarFactory;
+import org.chocosolver.solver.variables.IDirectedGraphVar;
+import org.chocosolver.solver.variables.VF;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.objects.graphs.DirectedGraph;
+import org.chocosolver.util.objects.setDataStructures.SetType;
+import org.chocosolver.util.objects.setDataStructures.iterableSet.ItSet;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+/**
+ * Tests for {@code GraphConstraintFactory#postSymmetryBreaking(IDirectedGraphVar, Solver) postSymmetryBreaking}/
+ * Symmetry breaking is using in next problem: given n and m.
+ * <br/>
+ * Find whether exists directed graph with n nodes, m edges, containing directed spanning tree from 0
+ * and with no circuit.
+ * <br/>
+ * Tests contain equivalence of existance of solution
+ * with symmetry breaking predicates and without them.
+ *
+ * @author Моклев Вячеслав
+ */
+public class SymmetryBreakingDirectedTest {
+    private static PrintStream oldOut;
+
+    private static Constraint containsDirectedTree(IDirectedGraphVar graph) {
+        return new Constraint("subTree", new Propagator<IDirectedGraphVar>(new IDirectedGraphVar[] {graph}, PropagatorPriority.LINEAR, false) {
+            IDirectedGraphVar graph = vars[0];
+            int n = graph.getNbMaxNodes();
+
+            void dfs(boolean[] used, int u) {
+                used[u] = true;
+                for (int v: new ItSet(graph.getPotSuccOf(u))) {
+                    if (!used[v]) {
+                        dfs(used, v);
+                    }
+                }
+            }
+
+            boolean entailed() {
+                boolean[] used = new boolean[n];
+                dfs(used, 0);
+                for (int i = 0; i < n; i++) {
+                    if (!used[i]) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            @Override
+            public void propagate(int i) throws ContradictionException {
+                if (!entailed()) {
+                    throw new ContradictionException();
+                }
+            }
+
+            @Override
+            public ESat isEntailed() {
+                if (entailed()) {
+                    if (graph.isInstantiated()) {
+                        return ESat.TRUE;
+                    }
+                    return ESat.UNDEFINED;
+                } else {
+                    return ESat.FALSE;
+                }
+            }
+        });
+    }
+
+    /**
+     * Tries to find a solution of the given problem
+     *
+     * @param n count of nodes
+     * @param m count of arcs
+     * @param addSymmetryBreaking enable symmetry breaking predicates or not
+     * @return true, if solution exists and false otherwise
+     */
+    private static boolean solutionExists(int n, int m, boolean addSymmetryBreaking) {
+        Solver solver = new Solver();
+        DirectedGraph GLB = new DirectedGraph(solver, n, SetType.BITSET, true);
+        DirectedGraph GUB = new DirectedGraph(solver, n, SetType.BITSET, true);
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                GUB.addArc(i, j);
+            }
+        }
+        IDirectedGraphVar graph = GraphVarFactory.directed_graph_var("G", GLB, GUB, solver);
+
+        solver.set(GraphStrategyFactory.lexico(graph));
+
+        solver.post(containsDirectedTree(graph));
+        solver.post(GCF.nb_arcs(graph, VF.fixed(m, solver)));
+        solver.post(GCF.no_circuit(graph));
+
+        // add symmetry breaking constraint if necessary
+        if (addSymmetryBreaking) {
+            GCF.postSymmetryBreaking(graph, solver);
+        }
+        return solver.findSolution();
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        oldOut = System.out;
+        System.setOut(new PrintStream(new OutputStream() {
+            @Override public void write(int b) throws IOException {}
+        }));
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        System.setOut(oldOut);
+    }
+
+    /**
+     * Checks equivalence of existance of solution
+     * with and without symmetry breaking.
+     *
+     * @param n count of nodes
+     * @param m count of arcs
+     */
+    public static void test(int n, int m) {
+        Assert.assertEquals(
+                solutionExists(n, m, true),
+                solutionExists(n, m, false),
+                "symmetry breaking: " + n + ", " + m
+        );
+    }
+
+    @Test
+    public static void testAll() {
+        for (int n = 0; n < 10; n++) {
+            for (int m = 0; m < n * n; m++) {
+                test(n, m);
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/chocosolver/SymmetryBreakingTest.java
+++ b/src/test/java/org/chocosolver/SymmetryBreakingTest.java
@@ -1,0 +1,236 @@
+package org.chocosolver;
+
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.cstrs.GCF;
+import org.chocosolver.solver.search.GraphStrategyFactory;
+import org.chocosolver.solver.variables.GraphVarFactory;
+import org.chocosolver.solver.variables.IUndirectedGraphVar;
+import org.chocosolver.solver.variables.VF;
+import org.chocosolver.util.Pair;
+import org.chocosolver.util.PropGirth;
+import org.chocosolver.util.objects.graphs.UndirectedGraph;
+import org.chocosolver.util.objects.setDataStructures.SetType;
+import org.chocosolver.util.objects.setDataStructures.iterableSet.ItSet;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.HashSet;
+
+/**
+ * Tests for {@code GraphConstraintFactory#postSymmetryBreaking(IUndirectedGraphVar, Solver) postSymmetryBreaking},
+ * {@code GraphConstraintFactory#symmetryBreaking2(IUndirectedGraphVar, Solver) symmetryBreaking2} and
+ * {@code GraphConstraintFactory#symmetryBreaking3(IUndirectedGraphVar, Solver) symmetryBreaking3}.
+ * Symmetry breaking is using in next problem: given n, m and l – integers.
+ * <br/>
+ * Find whether exists undirected connected graph with n nodes, m edges
+ * and with girth equals to l.
+ * <br/>
+ * Tests contain checking correctness of answers found and equivalence of existance of solution
+ * with symmetry breaking predicates and without them.
+ *
+ * @author Моклев Вячеслав
+ */
+public class SymmetryBreakingTest {
+    private static PrintStream oldOut;
+
+    /**
+     * Calculates a girth of a given graph.
+     *
+     * @param graph given graph
+     * @return girth of {@code graph}
+     */
+    private static int getGraphGirth(IUndirectedGraphVar graph) {
+        int n = graph.getNbMaxNodes();
+        int g = n + 1;
+        for (int i = 0; i < n; i++) {
+            int pg = getGraphVertexGirth(graph, i);
+            if (pg < g) {
+                g = pg;
+            }
+        }
+        return g;
+    }
+
+    private static int getGraphVertexGirth(IUndirectedGraphVar graph, int vertex) {
+        int n = graph.getNbMaxNodes();
+        HashSet<Pair<Integer, Integer>> reachable = new HashSet<>();
+        reachable.add(new Pair<>(vertex, -1));
+        for (int i = 1; i <= n; i++) {
+            HashSet<Pair<Integer, Integer>> set = new HashSet<>();
+            for (Pair<Integer, Integer> u: reachable) {
+                for (int v: new ItSet(graph.getMandNeighOf(u.getA()))) {
+                    if (v != u.getB()) {
+                        if (v == vertex) {
+                            return i;
+                        }
+                        set.add(new Pair<>(v, u.getA()));
+                    }
+                }
+            }
+            reachable = set;
+        }
+        return n + 1;
+    }
+
+    /**
+     * Tries to find a solution of the given problem and check it for correctness.
+     *
+     * @param n count of nodes
+     * @param m count of edges
+     * @param l required girth
+     * @param addSymmetryBreaking enable symmetry breaking predicates or not
+     * @throws AssertionError if solution found is not correct
+     * @return true, if solution exists and false otherwise
+     */
+    private static boolean solutionExists(int n, int m, int l, boolean addSymmetryBreaking) {
+        Solver solver = new Solver();
+        UndirectedGraph GLB = new UndirectedGraph(solver, n, SetType.BITSET, true);
+        UndirectedGraph GUB = new UndirectedGraph(solver, n, SetType.BITSET, true);
+        for (int i = 0; i < n; i++) {
+            for (int j = i + 1; j < n; j++) {
+                GUB.addEdge(i, j);
+            }
+        }
+        IUndirectedGraphVar graph = GraphVarFactory.undirected_graph_var("G", GLB, GUB, solver);
+        // graph mush contains n nodes, m edges and have girth exactly l
+        solver.set(GraphStrategyFactory.lexico(graph));
+        solver.post(GCF.nb_edges(graph, VF.fixed(m, solver)));
+        solver.post(GCF.connected(graph)); // GCF.postSymmetryBreaking is sb predicate only for connected undirected graphs
+        solver.post(new Constraint("GirthConstraint", new PropGirth(graph, VF.fixed(l, solver))));
+        // add symmetry breaking constraint if necessary
+        if (addSymmetryBreaking) {
+            // choose one to test
+            GCF.postSymmetryBreaking(graph, solver);
+//            solver.post(GCF.symmetryBreaking2(graph, solver));
+//            solver.post(GCF.symmetryBreaking3(graph, solver));
+        }
+        boolean result = solver.findSolution();
+        if (result) { // check correctness of found answer
+            int count = 0;
+            for (int u = 0; u < n; u++) {
+                for (int v: new ItSet(graph.getMandNeighOf(u))) {
+                    count++;
+                }
+            }
+            Assert.assertEquals(count, 2 * m, "correct number of edges");
+            Assert.assertEquals(getGraphGirth(graph), l, "correct girth");
+        }
+        return result;
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        oldOut = System.out;
+        System.setOut(new PrintStream(new OutputStream() {
+            @Override public void write(int b) throws IOException {}
+        }));
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        System.setOut(oldOut);
+    }
+
+    /**
+     * Checks equivalence of existance of solution
+     * with and without symmetry breaking.
+     *
+     * @param n count of nodes
+     * @param m count of edges
+     * @param l required girth
+     */
+    public static void test(int n, int m, int l) {
+        Assert.assertEquals(
+                solutionExists(n, m, l, true),
+                solutionExists(n, m, l, false),
+                "symmetry breaking: " + n + ", " + m + ", " + l
+        );
+    }
+
+    @Test
+    public static void testSimple1() {
+        test(1, 1, 1);
+    }
+
+    @Test
+    public static void testSimple2() {
+        test(5, 4, 2);
+    }
+
+    @Test
+    public static void testSimple3() {
+        test(3, 5, 4);
+    }
+
+    @Test
+    public static void testSimple4() {
+        test(2, 1, 3);
+    }
+
+    @Test
+    public static void testSimple5() {
+        test(3, 2, 3);
+    }
+
+    @Test
+    public static void testMedium1() {
+        test(4, 3, 3);
+    }
+
+    @Test
+    public static void testAllSmall() {
+        for (int n = 1; n <= 6; n++) {
+            for (int m = 1; m <= 6; m++) {
+                for (int l = 1; l <= 6; l++) {
+                    test(n, m, l);
+                }
+            }
+        }
+    }
+
+    // OEIS, A006856
+    private static final int[] a = new int[] {0, 0, 1, 2, 3, 5, 6, 8, 10, 12, 15, 16, 18, 21, 23, 36, 28, 31};
+
+    @Test
+    public static void testCorrectness() {
+        for (int n = 5; n <= 7; n++) {
+            Assert.assertEquals(solutionExists(n, a[n], 5, true), true);
+            Assert.assertEquals(solutionExists(n, a[n] + 1, 5, true), false);
+        }
+    }
+
+    @Test
+    public static void testCorrectness1() {
+        int n = 10;
+        Assert.assertEquals(solutionExists(n, a[n], 5, true), true);
+    }
+
+    @Test
+    public static void testCorrectness2() {
+        int n = 8;
+        Assert.assertEquals(solutionExists(n, a[n] + 1, 5, true), false);
+    }
+
+    @Test
+    public static void testHardNoSolution() {
+        Assert.assertEquals(
+                solutionExists(8, 10, 6, true),
+                false // it's preprocessed value of solutionExists(8, 10, 6, false), 70 seconds @ AMD FX-8150 (3.6 GHz, 8 Gb RAM)
+        );
+    }
+
+    @Test
+    public static void testHardSolutionExists() {
+        Assert.assertEquals(
+                solutionExists(10, 10, 9, true),
+                true // it's preprocessed value of solutionExists(10, 10, 9, false), 225 seconds @ AMD FX-8150 (3.6 GHz, 8 Gb RAM)
+        );
+    }
+
+}

--- a/src/test/java/org/chocosolver/util/Pair.java
+++ b/src/test/java/org/chocosolver/util/Pair.java
@@ -1,0 +1,22 @@
+package org.chocosolver.util;
+
+/**
+ * @author Моклев Вячеслав
+ */
+public class Pair<T, V> {
+    private T a;
+    private V b;
+
+    public Pair(T a, V b) {
+        this.a = a;
+        this.b = b;
+    }
+
+    public T getA() {
+        return a;
+    }
+
+    public V getB() {
+        return b;
+    }
+}

--- a/src/test/java/org/chocosolver/util/PropGirth.java
+++ b/src/test/java/org/chocosolver/util/PropGirth.java
@@ -1,0 +1,124 @@
+package org.chocosolver.util;
+
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IUndirectedGraphVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.util.objects.setDataStructures.iterableSet.ItSet;
+
+import java.util.HashSet;
+
+/**
+ * @author Моклев Вячеслав
+ */
+public class PropGirth extends Propagator<Variable> {
+    IUndirectedGraphVar graph;
+    int n;
+    IntVar girth;
+
+    public PropGirth(IUndirectedGraphVar graphVar, IntVar girth) {
+        super(new Variable[] {girth, graphVar}, PropagatorPriority.LINEAR, false);
+        graph = graphVar;
+        n = graphVar.getNbMaxNodes();
+        this.girth = girth;
+    }
+
+    @Override
+    public void propagate(int evtmask) throws ContradictionException {
+        int upperGraphGirth = getUpperGraphGirth();
+        int lowerGraphGirth = getLowerGraphGirth();
+        System.out.println("$org.chocosolver.solver.sbcstrs.test.util.PropGirth::propagate$> " + lowerGraphGirth + ", " + upperGraphGirth);
+        if (upperGraphGirth < girth.getUB()) {
+            girth.updateUpperBound(upperGraphGirth, this);
+        }
+        if (upperGraphGirth < girth.getLB()) {
+            throw new ContradictionException();
+        }
+        if (lowerGraphGirth > girth.getLB()) {
+            girth.updateLowerBound(lowerGraphGirth, this);
+        }
+        if (lowerGraphGirth > girth.getUB()) {
+            throw new ContradictionException();
+        }
+    }
+
+    @Override
+    public ESat isEntailed() {
+        int upperGraphGirth = getUpperGraphGirth();
+        int lowerGraphGirth = getLowerGraphGirth();
+        if (upperGraphGirth < girth.getLB()) {
+            return ESat.FALSE;
+        }
+        if (lowerGraphGirth > girth.getUB()) {
+            return ESat.FALSE;
+        }
+        if (graph.isInstantiated() && girth.isInstantiatedTo(lowerGraphGirth)) {
+            return ESat.TRUE;
+        }
+        return ESat.UNDEFINED;
+    }
+
+    private int getUpperGraphGirth() {
+        int g = n + 1;
+        for (int i = 0; i < n; i++) {
+            int pg = getUpperGraphGirth(i);
+            if (pg < g) {
+                g = pg;
+            }
+        }
+        return g;
+    }
+
+    private int getLowerGraphGirth() {
+        int g = n + 1;
+        for (int i = 0; i < n; i++) {
+            int pg = getLowerGraphGirth(i);
+            if (pg < g) {
+                g = pg;
+            }
+        }
+        return g;
+    }
+
+    private int getUpperGraphGirth(int vertex) {
+        HashSet<Pair<Integer, Integer>> reachable = new HashSet<>();
+        reachable.add(new Pair<>(vertex, -1));
+        for (int i = 1; i <= n; i++) {
+            HashSet<Pair<Integer, Integer>> set = new HashSet<>();
+            for (Pair<Integer, Integer> u: reachable) {
+                for (int v: new ItSet(graph.getMandNeighOf(u.getA()))) {
+                    if (v != u.getB()) {
+                        if (v == vertex) {
+                            return i;
+                        }
+                        set.add(new Pair<>(v, u.getA()));
+                    }
+                }
+            }
+            reachable = set;
+        }
+        return n + 1;
+    }
+
+    private int getLowerGraphGirth(int vertex) {
+        HashSet<Pair<Integer, Integer>> reachable = new HashSet<>();
+        reachable.add(new Pair<>(vertex, -1));
+        for (int i = 1; i <= n; i++) {
+            HashSet<Pair<Integer, Integer>> set = new HashSet<>();
+            for (Pair<Integer, Integer> u: reachable) {
+                for (int v: new ItSet(graph.getPotNeighOf(u.getA()))) {
+                    if (v != u.getB()) {
+                        if (v == vertex) {
+                            return i;
+                        }
+                        set.add(new Pair<>(v, u.getA()));
+                    }
+                }
+            }
+            reachable = set;
+        }
+        return n + 1;
+    }
+}


### PR DESCRIPTION
Hello, I'm a russian student from ITMO University, Computer Technology Department, Vyacheslav Moklev.
The main task of my course work was to implement different methods of symmetry breaking in graph representations using existing graph constraint solver like choco and choco-graph.
I implemented 3 methods, mainly based on these papers:

1. Ulyantsev V., Zakirzyanov I., Shalyto A.
    **BFS-Based Symmetry Breaking Predicates for DFA Identification**
    _//Language and Automata Theory and Applications. – Springer International Publishing, 2015. – P. 611-622._

2. Codish M. et al. 
**Breaking Symmetries in Graph Representation** 
_//IJCAI. – 2013. – P. 3-9._

The first method was initially developed for breaking symmetries for finite automata without unreachable states. So its adaptation for graphs is limited: it provides symmetry breaking predicate for connected undirected graphs or for directed graphs which contain a directed spanning tree from vertex 0.

Second and third methods are applicable only for undirected graphs, but without restriction on connectivity.

I also implemented some tests for these methods. 
For undirected graphs the following problem was used:
Given n, m and l, find a graph with n nodes, m edges and girth at least l.
(Girth is the length of shortest circuit.)
This problem was solved in many papers and there is a sequence on OEIS (A006856),
which contains maximal number of edges in n-node graph of girth at least 5.
This sequence was used to check correctness of methods' implementation.

Symmetry breaking predicates are intended to speed up rate of solving problem instances,
so here are time comparison tables: 
(T1 – time without symmetry breaking,
T2 – time with BFS-based method, (GCF.symmetryBreaking)
T3 – time with adjacency matrix-based method, (GCF.symmetryBreaking2)
T4 – time with matrix-based improved method (GCF.symmetryBreaking3)
time* means that calculation was longer, than 'time')

|    n, m, l      |    T1, sec     |    T2, sec    |    T3, sec    |    T4, sec    |
|-----------------|--------------|-------------|-------------|-------------|
|    4, 6, 3      |    0,5       |    0,28     |    0,32     |    0,33     |
|    6, 8, 4      |    0,26      |    0,34     |    0,37     |    0,35     |
|    8, 10, 5     |    1,21      |    0,75     |    0,59     |    0,52     |
|    10, 12, 6    |    24,5      |    2,4      |    1,1      |    1,0      |
|    12, 14, 7    |    57600*    |    49       |    52       |    13,3     |
|    14, 16, 8    |    –         |    650      |    1806     |    307      |

|    n, m, l       |    T1, sec    |    T2, sec    |    T3, sec    |    T4, sec    |
|------------------|-------------|-------------|-------------|-------------|
|    5, 5, 4       |    0,20     |    0,31     |    0,36     |    0,40     |
|    6, 6, 5       |    0,25     |    0,37     |    0,36     |    0,41     |
|    7, 7, 6       |    0,38     |    0,50     |    0,41     |    0,45     |
|    8, 8, 7       |    1,2      |    0,8      |    0,52     |    0,60     |
|    9, 9, 8       |    11,6     |    1,6      |    0,82     |    0,9      |
|    10, 10, 9     |    226      |    4,2      |    1,9      |    1,9      |
|    11, 11, 10    |    5525     |    14,6     |    7,3      |    6,3      |
|    12, 12, 11    |    7200*    |    81,1     |    49,2     |    34,5     |
|    13, 13, 12    |    7200*    |    354      |    380      |    208      |

|        n    |    m = f4(n)    |             |             |             | m = f4(n) + 1 |             |             |            |
|-------------|-----------------|-------------|-------------|-------------|---------------|-------------|-------------|------------|
|             |    T1, sec        |    T2, sec    |    T3, sec    |    T4, sec    |    T1, sec      |    T2, sec    |    T3, sec    |    T4, sec        |
|    5        |    0,23         |    0,36     |    0,35     |    0,35     |    0,31       |    0,35     |    0,40     |    0,38    |
|    6        |    0,24         |    0,37     |    0,36     |    0,39     |    0,66       |    0,44     |    0,56     |    0,43    |
|    7        |    0,36         |    0,47     |    0,42     |    0,40     |    4,2        |    0,66     |    0,61     |    0,60    |
|    8        |    1,2          |    0,67     |    0,59     |    0,51     |    96         |    1,2      |    1,1      |    0,94    |
|    9        |    14,2         |    1,3      |    1,0      |    0,8      |    3503       |    3,2      |    3,6      |    2,5     |
|    10       |    382          |    3,7      |    3,4      |    1,6      |    7200*      |    11,3     |    19,5     |    9,6     |
|    11       |    ?*           |    7,7      |    7,4      |    2,3      |    –          |    114      |    268      |    102     |
|    12       |    7200*        |    96       |    61       |    13,2     |    –          |    1190     |    3684     |    1172    |
|    13       |    –            |    1279     |    807      |    166      |    –          |    ?        |    ?        |    ?       |

These tables show that implemented methods highly increase efficiency of solver in such problems.

There are also tests for directed graphs with the following problem: given n and m, find a graph with n nodes, m arcs, with directed spanning tree from node 0 and with no circuits. All tests are successfully passed.

My scientific adviser Vladimir Ulyantsev, author of first the paper mentioned above, had a small conversation about contribution and received the following answer:

> Dear Vladimir,
Sure! Feel free to contribute to choco-graph. 
Symmetry breaking is indeed very important and it would be good having such a constraint.
Your students could fork the project with a new branch on GitHub and then submit a pull request for merge validation.
The documentation shows how to implement your own constraint (https://github.com/chocoteam/choco-graph/blob/master/doc/ChocoGraphDoc.pdf). 
Keep me informed ;-)
Best, Jean-Guillaume FAGES, PhD

So here it is, pull request of implemented methods.

Vyacheslav Moklev, M3339 ITMO study group 17', Computer Technologies Department.